### PR TITLE
Load bonds in regulations from contract emitted events

### DIFF
--- a/src/views/Home/Home.js
+++ b/src/views/Home/Home.js
@@ -335,11 +335,7 @@ const Home = () => {
                 </CardIcon>
               </Box>
               <Box mt={2}>
-                <Button
-                  color="primary"
-                  onClick={onPresentTshareZap}
-                  variant="contained"
-                >
+                <Button color="primary" onClick={onPresentTshareZap} variant="contained">
                   Zap In
                 </Button>
               </Box>

--- a/src/views/Regulations/Regulations.js
+++ b/src/views/Regulations/Regulations.js
@@ -47,9 +47,9 @@ const Regulations = () => {
   const classes = useStyles();
   const tombFinance = useTombFinance();
   const [rows, setRows] = useState(null);
-  function createData(epoch, dao, dev, masonry) {
+  function createData(epoch, dao, dev, masonry, bondsBought, bondsRedeemed) {
     var sum = (Number(dao) + Number(dev) + Number(masonry)).toFixed(2);
-    return { epoch, dao, dev, masonry, sum };
+    return { epoch, dao, dev, masonry, sum, bondsBought, bondsRedeemed };
   }
   useEffect(() => {
     if (tombFinance) {
@@ -58,7 +58,16 @@ const Regulations = () => {
         setRows(
           elements
             .reverse()
-            .map((element) => createData(element.epoch, element.daoFund, element.devFund, element.masonryFund)),
+            .map((element) =>
+              createData(
+                element.epoch,
+                element.daoFund,
+                element.devFund,
+                element.masonryFund,
+                element.bondsBought,
+                element.bondsRedeemed,
+              ),
+            ),
         );
       });
     }
@@ -96,8 +105,8 @@ const Regulations = () => {
                 <StyledTableCell align="center">{row.dao}</StyledTableCell>
                 <StyledTableCell align="center">{row.dev}</StyledTableCell>
                 <StyledTableCell align="center">{row.sum}</StyledTableCell>
-                <StyledTableCell align="center">0</StyledTableCell>
-                <StyledTableCell align="center">0</StyledTableCell>
+                <StyledTableCell align="center">{row.bondsBought}</StyledTableCell>
+                <StyledTableCell align="center">{row.bondsRedeemed}</StyledTableCell>
               </StyledTableRow>
             ))}
           </TableBody>


### PR DESCRIPTION
Since our Treasury
- does not emit an event for how many bonds where minted during epoch advancement
- does not emit an event for how many bonds where redeemed on the previous epoch

Those 2 numbers for the regulations page will need to be computed based on the emitted events:
- `BondsRedeemed`
- `BondsBought`

which are emitted when a user buys or redeems a bond.

With this PR logic is introduced to calculate what blockNumber each epoch started at and what blockNumber it ended.
Then for each period we are looking up the amount of BondsRedeemed and BondsBought events emitted.

For the current epoch where the ending block is not yet concluded, the query filter will default to `latest` if used with an empty `to` parameter.