### PR TITLE
Cache provider instead of creating new one each time

### DIFF
--- a/src/tomb-finance/TombFinance.ts
+++ b/src/tomb-finance/TombFinance.ts
@@ -7,7 +7,7 @@ import { BigNumber, Contract, ethers, EventFilter } from 'ethers';
 import { decimalToBalance } from './ether-utils';
 import { TransactionResponse } from '@ethersproject/providers';
 import ERC20 from './ERC20';
-import { getFullDisplayBalance, getDisplayBalance, getBalance } from '../utils/formatBalance';
+import { getFullDisplayBalance, getDisplayBalance } from '../utils/formatBalance';
 import { getDefaultProvider } from '../utils/provider';
 import IUniswapV2PairABI from './IUniswapV2Pair.abi.json';
 import config, { bankDefinitions } from '../config';
@@ -755,7 +755,7 @@ export class TombFinance {
     const boughtBondsFilter = Treasury.filters.BoughtBonds();
     const redeemBondsFilter = Treasury.filters.RedeemedBonds();
 
-    let epochBlocksRanges = new Array();
+    let epochBlocksRanges: any[] = [];
     let masonryFundEvents = await Treasury.queryFilter(treasuryMasonryFundedFilter);
     var events: any[] = [];
     masonryFundEvents.forEach(function callback(value, index) {

--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -2,6 +2,12 @@ import { ethers } from 'ethers';
 import config from '../config';
 import { web3ProviderFrom } from '../tomb-finance/ether-utils';
 
+let provider: ethers.providers.Web3Provider = null;
+
 export function getDefaultProvider(): ethers.providers.Web3Provider {
-  return new ethers.providers.Web3Provider(web3ProviderFrom(config.defaultProvider), config.chainId);
+  if (!provider) {
+    provider = new ethers.providers.Web3Provider(web3ProviderFrom(config.defaultProvider), config.chainId);
+  }
+
+  return provider;
 }


### PR DESCRIPTION
Previously this code would create a new instance of a provider which lead to duplicate websocket creations or RPC HTTP calls in the case of an http url provider. This caches it on load and references the same one unless the user refreshes.